### PR TITLE
Enable multithreaded build on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
 script:
   - sudo ln -sf /usr/bin/gcov-4.9 /usr/bin/gcov
   - bash -e tools/infrastructure/check_style.sh
-  - mkdir build && cd build && cmake ../ -DBUILD_TESTS=ON -DENABLE_GCOV=ON && make install
+  - mkdir build && cd build && cmake ../ -DBUILD_TESTS=ON -DENABLE_GCOV=ON && make install -j2
   - sudo ldconfig
   - make test
   - bash ../tools/infrastructure/show_disabled.sh


### PR DESCRIPTION
Added changes in .travis.yml to build in parallel mode, namely added -j2 parameter on "make install"

Related to [APPLINK-28056](https://adc.luxoft.com/jira/browse/APPLINK-28056)
